### PR TITLE
fix(eval): support Vertex global endpoint

### DIFF
--- a/examples/eval/scripts/generate.mjs
+++ b/examples/eval/scripts/generate.mjs
@@ -482,9 +482,11 @@ export async function generateWithVertex(prompt, { env, model, temperature, resp
     throw new Error('Set GCP_PROJECT_ID before using --backend vertex.');
   }
   const { VertexAI } = await import('@google-cloud/vertexai');
+  const location = env.VERTEX_REGION ?? 'us-central1';
   const vertexAI = new VertexAI({
     project: env.GCP_PROJECT_ID ?? '',
-    location: env.VERTEX_REGION ?? 'us-central1',
+    location,
+    apiEndpoint: resolveVertexApiEndpoint(env, location),
   });
   const generativeModel = vertexAI.getGenerativeModel({
     model,
@@ -505,6 +507,14 @@ export async function generateWithVertex(prompt, { env, model, temperature, resp
     .flatMap((candidate) => candidate.content?.parts ?? [])
     .map((part) => part.text ?? '')
     .join('');
+}
+
+export function resolveVertexApiEndpoint(env, location) {
+  if (typeof env.VERTEX_API_ENDPOINT === 'string' && env.VERTEX_API_ENDPOINT.trim()) {
+    return env.VERTEX_API_ENDPOINT.trim();
+  }
+  if (location === 'global') return 'aiplatform.googleapis.com';
+  return undefined;
 }
 
 async function runPool(items, concurrency, worker) {

--- a/examples/eval/scripts/generate.test.mjs
+++ b/examples/eval/scripts/generate.test.mjs
@@ -8,6 +8,7 @@ import {
   buildDocumentPrompt,
   normalizeGeneratedText,
   parseArgs,
+  resolveVertexApiEndpoint,
   runGenerate,
 } from './generate.mjs';
 
@@ -80,6 +81,15 @@ test('generate arg parser protects previews and concurrency', () => {
       '/private/tmp/preview',
     ]).kind,
     'usage-error',
+  );
+});
+
+test('resolveVertexApiEndpoint uses global host for global Vertex models', () => {
+  assert.equal(resolveVertexApiEndpoint({}, 'us-central1'), undefined);
+  assert.equal(resolveVertexApiEndpoint({}, 'global'), 'aiplatform.googleapis.com');
+  assert.equal(
+    resolveVertexApiEndpoint({ VERTEX_API_ENDPOINT: 'custom-aiplatform.example.test' }, 'global'),
+    'custom-aiplatform.example.test',
   );
 });
 


### PR DESCRIPTION
## Summary

- Fix eval Vertex generation when `VERTEX_REGION=global` by overriding the SDK host to `aiplatform.googleapis.com`.
- Keep existing regional behavior unchanged.
- Add a regression test for the global endpoint resolver and explicit `VERTEX_API_ENDPOINT` override.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `node --test examples/eval/scripts/generate.test.mjs examples/eval/scripts/direct-open-schema.test.mjs` passed: 22/22

## Notes

This was hit while running the Maya packet-medium direct open-schema baseline with `gemini-3.1-flash-lite`, which is available through Vertex global.
