### PR TITLE
Handle null form-fill action values

### DIFF
--- a/apps/backend/src/modules/preferences/form-fill/form-fill.types.spec.ts
+++ b/apps/backend/src/modules/preferences/form-fill/form-fill.types.spec.ts
@@ -1,0 +1,25 @@
+import { FormFillAiResponseSchema } from './form-fill.types';
+
+describe('FormFillAiResponseSchema', () => {
+  it('normalizes null action values from model output to missing values', () => {
+    const parsed = FormFillAiResponseSchema.parse({
+      fillActions: [
+        {
+          fieldName: 'payphone',
+          action: 'SET_TEXT',
+          value: null,
+          sourceSlugs: ['profile.phone'],
+          confidence: 0.8,
+        },
+      ],
+    });
+
+    expect(parsed.fillActions[0]).toMatchObject({
+      fieldName: 'payphone',
+      action: 'SET_TEXT',
+      sourceSlugs: ['profile.phone'],
+      confidence: 0.8,
+    });
+    expect(parsed.fillActions[0].value).toBeUndefined();
+  });
+});

--- a/apps/backend/src/modules/preferences/form-fill/form-fill.types.ts
+++ b/apps/backend/src/modules/preferences/form-fill/form-fill.types.ts
@@ -124,7 +124,10 @@ export type FormFillFieldPolicies = z.infer<
 export const FillActionSchema = z.object({
   fieldName: z.string(),
   action: z.enum(['SET_TEXT', 'CHECK', 'UNCHECK', 'SELECT_OPTION', 'SKIP']),
-  value: z.string().optional(),
+  value: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.string().optional(),
+  ),
   sourceSlugs: z.array(z.string()).optional().default([]),
   confidence: z.number().min(0).max(1).optional(),
   skipReason: z.string().optional(),


### PR DESCRIPTION
## Summary
- normalize null AI fill action values to missing values before form-fill validation
- add a unit test covering null values from model output

## Verification
- pnpm --filter backend test -- form-fill.types.spec.ts --runInBand
- pnpm --filter backend test -- form-fill-validator.service.spec.ts --runInBand
- pnpm --filter backend test -- form-fill.service.spec.ts --runInBand
- reran oracle CR memory packet after the fix: pass, 3 scenarios