### PR TITLE
Support digit-position render hints for split PDF fields

### DIFF
--- a/examples/eval/forms/direct-deposit-sf1199a-24/field-map.json
+++ b/examples/eval/forms/direct-deposit-sf1199a-24/field-map.json
@@ -41,86 +41,98 @@
     {
       "fieldIndex": 4,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct1[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:0",
+      "note": "Depositor account-number digit 1."
     },
     {
       "fieldIndex": 5,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct2[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:1",
+      "note": "Depositor account-number digit 2."
     },
     {
       "fieldIndex": 6,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct3[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:2",
+      "note": "Depositor account-number digit 3."
     },
     {
       "fieldIndex": 7,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct4[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:3",
+      "note": "Depositor account-number digit 4."
     },
     {
       "fieldIndex": 8,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct5[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:4",
+      "note": "Depositor account-number digit 5."
     },
     {
       "fieldIndex": 9,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct6[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:5",
+      "note": "Depositor account-number digit 6."
     },
     {
       "fieldIndex": 10,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct7[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:6",
+      "note": "Depositor account-number digit 7."
     },
     {
       "fieldIndex": 11,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct8[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:7",
+      "note": "Depositor account-number digit 8."
     },
     {
       "fieldIndex": 12,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct9[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:8",
+      "note": "Depositor account-number digit 9."
     },
     {
       "fieldIndex": 13,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct10[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:9",
+      "note": "Depositor account-number digit 10."
     },
     {
       "fieldIndex": 14,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct11[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:10",
+      "note": "Depositor account-number digit 11."
     },
     {
       "fieldIndex": 15,
       "pdfFieldName": "topmostSubform[0].Page1[0].acct12[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split depositor account-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.accountNumber",
+      "render": "digit-at:11",
+      "note": "Depositor account-number digit 12."
     },
     {
       "fieldIndex": 16,
@@ -405,65 +417,74 @@
     {
       "fieldIndex": 56,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout1[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:0",
+      "note": "Routing number digit 1."
     },
     {
       "fieldIndex": 57,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout2[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:1",
+      "note": "Routing number digit 2."
     },
     {
       "fieldIndex": 58,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout3[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:2",
+      "note": "Routing number digit 3."
     },
     {
       "fieldIndex": 59,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout4[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:3",
+      "note": "Routing number digit 4."
     },
     {
       "fieldIndex": 60,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout5[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:4",
+      "note": "Routing number digit 5."
     },
     {
       "fieldIndex": 61,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout6[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:5",
+      "note": "Routing number digit 6."
     },
     {
       "fieldIndex": 62,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout7[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:6",
+      "note": "Routing number digit 7."
     },
     {
       "fieldIndex": 63,
       "pdfFieldName": "topmostSubform[0].Page1[0].rout8[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:7",
+      "note": "Routing number digit 8."
     },
     {
       "fieldIndex": 64,
       "pdfFieldName": "topmostSubform[0].Page1[0].ckdigit[0]",
-      "mode": "skip",
-      "reason": "out_of_scope",
-      "note": "Split routing-number digit box deferred for v1; mapping it cleanly needs a digit-position renderer or form-ready digit facts."
+      "mode": "fact",
+      "factKey": "banking.routingNumber",
+      "render": "digit-at:8",
+      "note": "Routing number check digit."
     },
     {
       "fieldIndex": 65,

--- a/examples/eval/schemas/field-map.schema.json
+++ b/examples/eval/schemas/field-map.schema.json
@@ -36,7 +36,15 @@
                 "type": "string"
               },
               "render": {
-                "enum": ["digits-only", "mmddyyyy"]
+                "oneOf": [
+                  {
+                    "enum": ["digits-only", "mmddyyyy"]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "^digit-at:(0|[1-9][0-9]*)$"
+                  }
+                ]
               },
               "when": {
                 "$ref": "#/$defs/condition"

--- a/examples/eval/scripts/eval-runner/run.test.mjs
+++ b/examples/eval/scripts/eval-runner/run.test.mjs
@@ -122,6 +122,68 @@ test('runner value rendering and eval slug derivation are deterministic', () => 
     renderFieldValue('1994-07-18', { render: 'mmddyyyy' }),
     '07181994',
   );
+  assert.equal(
+    renderFieldValue('091-000-019', { render: 'digit-at:8' }),
+    '9',
+  );
+  assert.equal(
+    renderFieldValue('740182936451', { render: 'digit-at:11' }),
+    '1',
+  );
+});
+
+test('direct-deposit run plan scores routing and account digit boxes', async () => {
+  const fixture = await loadScenarioFixture({
+    repoRoot,
+    scenarioId: 'maya-chen-newhire-direct-deposit-packet-hard-required-v4',
+  });
+  const runPlan = buildRunPlan(fixture);
+
+  assert.equal(
+    actionFor(runPlan, 'topmostSubform[0].Page1[0].rout1[0]').fillAction.value,
+    '0',
+  );
+  assert.equal(
+    actionFor(runPlan, 'topmostSubform[0].Page1[0].ckdigit[0]').fillAction.value,
+    '9',
+  );
+  assert.equal(
+    actionFor(runPlan, 'topmostSubform[0].Page1[0].acct1[0]').fillAction.value,
+    '7',
+  );
+  assert.equal(
+    actionFor(runPlan, 'topmostSubform[0].Page1[0].acct12[0]').fillAction.value,
+    '1',
+  );
+  assert.equal(
+    actionFor(runPlan, 'topmostSubform[0].Page1[0].acct13[0]').fillAction.action,
+    'SKIP',
+  );
+
+  const snapshot = buildFilledFormSnapshot({
+    fixture,
+    runPlan,
+    harnessResult: fakeHarnessResult(runPlan),
+  });
+
+  assert.equal(
+    snapshot.fields.find(
+      (field) => field.pdfFieldName === 'topmostSubform[0].Page1[0].rout1[0]',
+    ).classification,
+    'correct',
+  );
+  assert.equal(
+    snapshot.fields.find(
+      (field) => field.pdfFieldName === 'topmostSubform[0].Page1[0].acct12[0]',
+    ).classification,
+    'correct',
+  );
+  assert.equal(
+    snapshot.fields.find(
+      (field) => field.pdfFieldName === 'topmostSubform[0].Page1[0].acct13[0]',
+    ).classification,
+    'skipped-correctly',
+  );
 });
 
 test('run plan applies conditional I-9 citizenship branches', async () => {

--- a/examples/eval/scripts/field-map.mjs
+++ b/examples/eval/scripts/field-map.mjs
@@ -1,6 +1,7 @@
 import { getFactValue } from './shared.mjs';
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DIGIT_AT_RENDER_PATTERN = /^digit-at:(0|[1-9]\d*)$/;
 
 export const CONDITIONAL_INACTIVE_SKIP_KIND = 'conditional-inactive';
 
@@ -36,17 +37,30 @@ export function renderFieldValue(value, fieldMap) {
   if (fieldMap.render === 'mmddyyyy') {
     return renderMmddyyyy(value);
   }
+  const digitAt = parseDigitAtRender(fieldMap.render);
+  if (digitAt != null) {
+    return rendered.replace(/\D/g, '').charAt(digitAt);
+  }
   return rendered;
 }
 
 export function fieldValuesEquivalent(expected, actual, fieldMap) {
   if (expected == null || actual == null) return expected === actual;
+  if (parseDigitAtRender(fieldMap?.render) != null) {
+    return String(expected) === String(actual);
+  }
   if (fieldMap?.render === 'digits-only' || fieldMap?.render === 'mmddyyyy') {
     const expectedDigits = String(expected).replace(/\D/g, '');
     const actualDigits = String(actual).replace(/\D/g, '');
     return expectedDigits.length > 0 && expectedDigits === actualDigits;
   }
   return actual === expected;
+}
+
+function parseDigitAtRender(render) {
+  if (typeof render !== 'string') return null;
+  const match = render.match(DIGIT_AT_RENDER_PATTERN);
+  return match ? Number(match[1]) : null;
 }
 
 function renderMmddyyyy(value) {

--- a/examples/eval/scripts/fill-form.test.mjs
+++ b/examples/eval/scripts/fill-form.test.mjs
@@ -340,8 +340,28 @@ test('buildFormFillFieldPolicies covers packet-small W-4 and direct-deposit slug
     'profile.address.line1',
     'eval.address.current.street_line',
   ]);
-  assertNoFactPolicy(directDeposit, 'banking.routingNumber');
-  assertNoFactPolicy(directDeposit, 'banking.accountNumber');
+  assertFieldSourceSlugs(
+    directDeposit,
+    'banking.routingNumber',
+    [
+      'eval.banking.routing_number',
+      'banking.routing_number',
+      'banking.routingNumber',
+      'profile.banking.routing_number',
+    ],
+    { count: 9 },
+  );
+  assertFieldSourceSlugs(
+    directDeposit,
+    'banking.accountNumber',
+    [
+      'eval.banking.account_number',
+      'banking.account_number',
+      'banking.accountNumber',
+      'profile.banking.account_number',
+    ],
+    { count: 12 },
+  );
 });
 
 test('fill-form writes filled-form, filled PDF, redacted response, and form score report', async () => {
@@ -723,24 +743,21 @@ async function fieldPoliciesForScenario({ scenarioId, storageMap }) {
   return buildFormFillFieldPolicies({ fixture, storageMap });
 }
 
-function assertFieldSourceSlugs(policies, factKey, sourceSlugs) {
+function assertFieldSourceSlugs(policies, factKey, sourceSlugs, options = {}) {
   const fields = policies.fields.filter(
     (field) => field.mode === 'fact' && field.factKey === factKey,
   );
   assert.ok(fields.length > 0, `expected at least one field policy for ${factKey}`);
+  if (options.count != null) {
+    assert.equal(
+      fields.length,
+      options.count,
+      `expected ${options.count} field policies for ${factKey}`,
+    );
+  }
   for (const field of fields) {
     assert.deepEqual(field.sourceSlugs, sourceSlugs, field.fieldName);
   }
-}
-
-function assertNoFactPolicy(policies, factKey) {
-  assert.equal(
-    policies.fields.some(
-      (field) => field.mode === 'fact' && field.factKey === factKey,
-    ),
-    false,
-    `expected no field policy for ${factKey}`,
-  );
 }
 
 function baseArgs(outPath) {

--- a/examples/eval/scripts/scoring/form.test.mjs
+++ b/examples/eval/scripts/scoring/form.test.mjs
@@ -4,6 +4,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { buildRunPlan } from '../eval-runner/actions.mjs';
+import { loadScenarioFixture } from '../eval-runner/fixtures.mjs';
+import { buildFilledFormSnapshot } from '../eval-runner/snapshots.mjs';
 import { scoreForm } from './form.mjs';
 import { validateWithSchema } from './io.mjs';
 import { jsonText } from '../shared.mjs';
@@ -346,3 +349,121 @@ test('form scorer maps unexpected should-fill snapshot classifications in band',
     'form fill score report',
   );
 });
+
+test('form scorer scores direct-deposit routing and account digit boxes', async () => {
+  const fixture = await loadScenarioFixture({
+    repoRoot,
+    scenarioId: 'maya-chen-newhire-direct-deposit-packet-hard-required-v4',
+  });
+  const runPlan = buildRunPlan(fixture);
+  const harnessResult = fakeHarnessResult(runPlan);
+  const missingRoutingField = 'topmostSubform[0].Page1[0].rout1[0]';
+  const wrongAccountField = 'topmostSubform[0].Page1[0].acct12[0]';
+  delete harnessResult.filledPdfFields[missingRoutingField];
+  harnessResult.response.summary.filledFields =
+    harnessResult.response.summary.filledFields.filter(
+      (field) => field.pdfFieldName !== missingRoutingField,
+    );
+  harnessResult.response.summary.filledCount -= 1;
+  harnessResult.response.summary.skippedCount += 1;
+  harnessResult.filledPdfFields[wrongAccountField].value = '0';
+
+  const snapshot = buildFilledFormSnapshot({
+    fixture,
+    runPlan,
+    harnessResult,
+  });
+
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'score-form-direct-deposit-'));
+  const filledFormPath = path.join(tmp, 'filled-form.json');
+  await writeFile(filledFormPath, jsonText(snapshot));
+
+  const report = await scoreForm({
+    repoRoot,
+    scenarioId: 'maya-chen-newhire-direct-deposit-packet-hard-required-v4',
+    filledFormPath,
+  });
+
+  assert.equal(
+    report.fields.find(
+      (field) => field.pdfFieldName === 'topmostSubform[0].Page1[0].ckdigit[0]',
+    ).classification,
+    'form_known_correct',
+  );
+  assert.equal(
+    report.fields.find((field) => field.pdfFieldName === missingRoutingField)
+      .classification,
+    'form_known_missing',
+  );
+  assert.equal(
+    report.fields.find((field) => field.pdfFieldName === wrongAccountField)
+      .classification,
+    'form_known_wrong',
+  );
+  assert.equal(
+    report.fields.find(
+      (field) => field.pdfFieldName === 'topmostSubform[0].Page1[0].acct13[0]',
+    ).classification,
+    'structural_skip',
+  );
+
+  await validateWithSchema(
+    repoRoot,
+    'form-fill-score-report.schema.json',
+    report,
+    'form fill score report',
+  );
+});
+
+function fakeHarnessResult(runPlan) {
+  const filledActions = runPlan.actionPlans.filter(
+    (plan) => plan.fillAction.action !== 'SKIP',
+  );
+  const skippedActions = runPlan.actionPlans.filter(
+    (plan) => plan.fillAction.action === 'SKIP',
+  );
+  const filledPdfFields = {};
+  for (const plan of filledActions) {
+    if (plan.fillAction.action === 'SET_TEXT') {
+      filledPdfFields[plan.pdfFieldName] = { value: plan.fillAction.value };
+    } else if (plan.fillAction.action === 'SELECT_OPTION') {
+      filledPdfFields[plan.pdfFieldName] = {
+        selected: [plan.fillAction.value],
+      };
+    } else if (plan.fillAction.action === 'CHECK') {
+      filledPdfFields[plan.pdfFieldName] = { checked: true };
+    } else if (plan.fillAction.action === 'UNCHECK') {
+      filledPdfFields[plan.pdfFieldName] = { checked: false };
+    }
+  }
+
+  return {
+    response: {
+      status: 'partial',
+      originalFilename: 'form.pdf',
+      outputFilename: 'filled-form.pdf',
+      outputMimeType: 'application/pdf',
+      filledPdfBase64: 'omitted-in-tests',
+      summary: {
+        totalFields: runPlan.actionPlans.length,
+        filledCount: filledActions.length,
+        skippedCount: skippedActions.length,
+        filledFields: filledActions.map((plan) => ({
+          pdfFieldName: plan.pdfFieldName,
+          fieldType: plan.fieldType,
+          sourceSlugs: plan.fillAction.sourceSlugs,
+          confidence: plan.fillAction.confidence,
+        })),
+        skippedFields: skippedActions.map((plan) => ({
+          pdfFieldName: plan.pdfFieldName,
+          fieldType: plan.fieldType,
+          reason: plan.fillAction.skipReason,
+          sourceSlugs: plan.fillAction.sourceSlugs,
+          confidence: plan.fillAction.confidence,
+        })),
+        warnings: [],
+      },
+    },
+    filledPdfFields,
+  };
+}

--- a/examples/eval/scripts/validate.test.mjs
+++ b/examples/eval/scripts/validate.test.mjs
@@ -170,12 +170,28 @@ test('reports invalid V2 field-map condition and render hints', async (t) => {
   const fieldMap = await readJson(fieldMapPath);
   fieldMap.fields[2].when = { factKey: 'identity.notReal', equals: 'x' };
   fieldMap.fields[15].render = 'slashes';
+  fieldMap.fields[17].render = 'digit-at:-1';
   fieldMap.fields[16].when = { factKey: 'identity.firstName', equals: [] };
   await writeJson(fieldMapPath, fieldMap);
 
   const result = await validateElena(root);
   assertHasCode(result, 'FIELD_MAP_CONDITION_FACT_MISSING');
   assertHasCode(result, 'SCHEMA_VALIDATION_FAILED');
+});
+
+test('accepts V2 field-map digit-position render hints', async (t) => {
+  const root = await copyRepo(t);
+  const fieldMapPath = path.join(
+    root,
+    'examples/eval/forms/i-9/field-map.json',
+  );
+  const fieldMap = await readJson(fieldMapPath);
+  fieldMap.fields[15].render = 'digit-at:0';
+  await writeJson(fieldMapPath, fieldMap);
+
+  const result = await validateElena(root);
+  assert.equal(result.exitCode, 0, formatResult(result));
+  assertNoCode(result, 'SCHEMA_VALIDATION_FAILED');
 });
 
 test('reports I-9 citizenship checkbox group with no active branch for profile value', async (t) => {


### PR DESCRIPTION
## Summary
- Add `digit-at:N` render support to the field-map schema and rendering logic.
- Map direct-deposit account and routing digit boxes to banking facts so split PDF fields can be filled and scored correctly.
- Extend validation and scoring tests to cover the new render hint and the direct-deposit flow.

## Testing
- Added unit coverage for `digit-at:N` rendering and equivalence behavior.
- Added integration coverage for direct-deposit run planning, field mapping, and form scoring.
- Added schema validation coverage for accepted and rejected render hints.